### PR TITLE
Allow standard output to be supressed

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -72,6 +72,9 @@ class JunitReporter extends events.EventEmitter {
     }
 
     getStandardOutput (test) {
+        if (this.options.writeStandardOutput === false) {
+            return ''
+        }
         let standardOutput = []
         test.output.forEach((data) => {
             switch (data.type) {


### PR DESCRIPTION
When writing data into a password field, the standard output from a command exposes the written password in plain text in the resulting test logs. This is very undesirable. Ideally, this would be handled at the webdriver/selenium level, but webdriver doesn't care [or know] what type of element is written to.

This PR hopes to remedy that by suppressing the standard output being written when the user explicitly supplies `writeStandardOutput: false` in the reporter settings:

Example:
```
reporterOptions: {
    junit: {
        outputDir: './path/to/test/results/',
        writeStandardOutput: false
    }
},
```