### PR TITLE
Added outputFileFormat config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ module.exports = {
   reporters: ['dot', 'junit'],
   reporterOptions: {
     outputDir: './',
-    outputFileFormat: 'results-{cid}.{capabilities}.xml' // optional
+    outputFileFormat: function(opts) { // optional
+        return `results-${opts.cid}.${opts.capabilities}.xml`
+    }
   },
   // ...
 };

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ module.exports = {
   // ...
   reporters: ['dot', 'junit'],
   reporterOptions: {
-    outputDir: './'
+    outputDir: './',
+    outputFileFormat: 'results-{cid}.{capabilities}.xml' // optional
   },
   // ...
 };

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -100,7 +100,7 @@ class JunitReporter extends events.EventEmitter {
 
         try {
             const dir = path.resolve(this.options.outputDir)
-            const filename = 'WDIO.xunit.' + capabilities.sanitizedCapabilities + '.' + cid + '.xml'
+            const filename = this.options.outputFileFormat ? this.options.outputFileFormat.replace("{capabilities}", capabilities.sanitizedCapabilities).replace("{cid}", cid) : 'WDIO.xunit.' + capabilities.sanitizedCapabilities + '.' + cid + '.xml'
             const filepath = path.join(dir, filename)
             mkdirp.sync(dir)
             fs.writeFileSync(filepath, xml)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -98,9 +98,16 @@ class JunitReporter extends events.EventEmitter {
             return console.log(`Cannot write xunit report: empty or invalid 'outputDir'.`)
         }
 
+        if (this.options.outputFileFormat && typeof this.options.outputFileFormat !== 'function') {
+            return console.log(`Cannot write xunit report: 'outputFileFormat' should be a function`)
+        }
+        
         try {
             const dir = path.resolve(this.options.outputDir)
-            const filename = this.options.outputFileFormat ? this.options.outputFileFormat.replace("{capabilities}", capabilities.sanitizedCapabilities).replace("{cid}", cid) : 'WDIO.xunit.' + capabilities.sanitizedCapabilities + '.' + cid + '.xml'
+            const filename = this.options.outputFileFormat ? this.options.outputFileFormat({
+                capabilities: capabilities.sanitizedCapabilities,
+                cid: cid
+            }) : `WDIO.xunit${capabilities.sanitizedCapabilities}.${cid}.xml`
             const filepath = path.join(dir, filename)
             mkdirp.sync(dir)
             fs.writeFileSync(filepath, xml)


### PR DESCRIPTION
The idea is to customize the results filename.

The strings "{cid}" and "{capabilities}" are considered "variables" and
are replaced in the string with cid and capabilities values.

Output file format example was added to the README.