### PR TITLE
Make config available on outputFileFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = {
   reporterOptions: {
     outputDir: './',
     outputFileFormat: function(opts) { // optional
-        return `results-${opts.cid}.${opts.capabilities}.xml`
+        return `results-${opts.cid}.${opts.capabilities}.${opts.config.suite}.xml`
     }
   },
   // ...

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ module.exports = {
   reporters: ['dot', 'junit'],
   reporterOptions: {
     outputDir: './',
-    outputFileFormat: function(opts) { // optional
-        return `results-${opts.cid}.${opts.capabilities}.${opts.config.suite}.xml`
+    outputFileFormat: function(opts) {
+      var suiteName = opts.config.suite.replace(/([^a-z0-9]+)/gi, '-');
+      return `results-${opts.cid}.${opts.capabilities}.${suiteName}.xml`;
     }
   },
   // ...

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -24,7 +24,7 @@ class JunitReporter extends events.EventEmitter {
             for (let cid of Object.keys(this.baseReporter.stats.runners)) {
                 const capabilities = this.baseReporter.stats.runners[cid]
                 const xml = this.prepareXml(capabilities)
-                this.write(capabilities, cid, xml)
+                this.write(capabilities, cid, xml, this.config)
             }
             epilogue.call(baseReporter)
         })
@@ -93,7 +93,7 @@ class JunitReporter extends events.EventEmitter {
         return standardOutput.length ? standardOutput.join('\n') : ''
     }
 
-    write (capabilities, cid, xml) {
+    write (capabilities, cid, xml, config) {
         if (!this.options || typeof this.options.outputDir !== 'string') {
             return console.log(`Cannot write xunit report: empty or invalid 'outputDir'.`)
         }
@@ -101,12 +101,13 @@ class JunitReporter extends events.EventEmitter {
         if (this.options.outputFileFormat && typeof this.options.outputFileFormat !== 'function') {
             return console.log(`Cannot write xunit report: 'outputFileFormat' should be a function`)
         }
-        
+
         try {
             const dir = path.resolve(this.options.outputDir)
             const filename = this.options.outputFileFormat ? this.options.outputFileFormat({
                 capabilities: capabilities.sanitizedCapabilities,
-                cid: cid
+                cid: cid,
+                config: config
             }) : `WDIO.xunit${capabilities.sanitizedCapabilities}.${cid}.xml`
             const filepath = path.join(dir, filename)
             mkdirp.sync(dir)


### PR DESCRIPTION
By making the config available as a parameter in the outputFileFormat function, it gives users the flexibility to name the output files according to the configs they have set.

I have a requirement where I need the .xml output file named by the suite I'm testing. I have updated the README to show this example as well.
