### PR TITLE
Added suiteNameFormat option for output xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ module.exports = {
   reporters: ['dot', 'junit'],
   reporterOptions: {
     outputDir: './',
-    outputFileFormat: function(opts) { // optional
+    outputFileFormat: function(opts) { // optional... will default to 'WDIO.xunit${capabilities.sanitizedCapabilities}.${cid}.xml'
         return `results-${opts.cid}.${opts.capabilities}.xml`
-    }
+    },
+    suiteNameFormat: /[^a-z]+/ // optional... will default to /[^a-z0-9]+/
   },
   // ...
 };

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -39,8 +39,9 @@ class JunitReporter extends events.EventEmitter {
 
             for (let suiteName of Object.keys(spec.suites)) {
                 const suite = spec.suites[suiteName]
+                const suiteNameRegEx = this.options.suiteNameFormat instanceof RegExp ? this.options.suiteNameFormat : /[^a-z0-9]+/
                 const testSuite = builder.testSuite()
-                    .name(suiteName.toLowerCase().split(/[^a-z0-9]+/).filter((item) => item && item.length).join('_'))
+                    .name(suiteName.toLowerCase().split(suiteNameRegEx).filter((item) => item && item.length).join('_'))
                     .timestamp(spec.suites[suiteName].start)
                     .time(spec.suites[suiteName].duration / 1000)
                     .property('specId', specId)


### PR DESCRIPTION
Gives the ability to provide custom regex for formatting test suite name (e.g. <testsuite name="">) in output xml.

I had a requirement where I was reading outputted junit xml from other script and was relying on value of <testsuite name=""> to include double underscores ('**') (e.g. <testsuite name="when a user does something __foo**">)
