### PR TITLE
added packageName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ You can break out packages by an additional level by setting `'packageName'` in 
   reporters: ['dot', 'junit'],
   reporterOptions: {
     showDiff: true,
-      outputDir: './',
-      packageName: process.env.USER_ROLE // chrome.41 - administrator
+    outputDir: './',
+    packageName: process.env.USER_ROLE // chrome.41 - administrator
   }
   // ...
 ```

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ module.exports = {
   // ...
 };
 ```
-
-To manually set the package name for publishing more elaborate Jenkins reports (instead of browser + version), just add a `'packageName'`:
+You can break out packages by an additional level by setting `'packageName'` in the config. For example, if you wanted to iterate over a test suite with different environemnt variable set:
 
 ```js
   // ...
@@ -53,7 +52,7 @@ To manually set the package name for publishing more elaborate Jenkins reports (
   reporterOptions: {
     showDiff: true,
       outputDir: './',
-      packageName: `${customPackageName}`
+      packageName: process.env.USER_ROLE // chrome.41 - administrator
   }
   // ...
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ module.exports = {
 };
 ```
 
+To manually set the package name for publishing more elaborate Jenkins reports (instead of browser + version), just add a `'packageName'`:
+
+```js
+  // ...
+  reporters: ['dot', 'junit'],
+  reporterOptions: {
+    showDiff: true,
+      outputDir: './',
+      packageName: `${customPackageName}`
+  }
+  // ...
+```
+
+
+
 Last but not least you nead to tell your CI job (e.g. Jenkins) where it can find the xml file. To do that add a post-build action to your job that gets executed after the test has run and point Jenkins (or your desired CI system) to your XML test results:
 
 ![Point Jenkins to XML files](http://webdriver.io/images/jenkins-postjob.png "Point Jenkins to XML files")

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -32,7 +32,7 @@ class JunitReporter extends events.EventEmitter {
 
     prepareXml (capabilities) {
         const builder = junit.newBuilder()
-        const packageName = this.options.packageName ? this.options.packageName : capabilities.sanitizedCapabilities;
+        const packageName = this.options.packageName ? `${capabilities.sanitizedCapabilities} - ${this.options.packageName}`: capabilities.sanitizedCapabilities;
 
         for (let specId of Object.keys(capabilities.specs)) {
             const spec = capabilities.specs[specId]

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -32,7 +32,7 @@ class JunitReporter extends events.EventEmitter {
 
     prepareXml (capabilities) {
         const builder = junit.newBuilder()
-        const packageName = capabilities.sanitizedCapabilities
+        const packageName = this.options.packageName ? this.options.packageName : capabilities.sanitizedCapabilities;
 
         for (let specId of Object.keys(capabilities.specs)) {
             const spec = capabilities.specs[specId]
@@ -101,7 +101,7 @@ class JunitReporter extends events.EventEmitter {
         if (this.options.outputFileFormat && typeof this.options.outputFileFormat !== 'function') {
             return console.log(`Cannot write xunit report: 'outputFileFormat' should be a function`)
         }
-        
+
         try {
             const dir = path.resolve(this.options.outputDir)
             const filename = this.options.outputFileFormat ? this.options.outputFileFormat({


### PR DESCRIPTION
Setting a different package/classname allows Jenkins' jUnit reporter to publish multiple results for the same test. For example, if I want to run the same tests against multiple roles:
` 
   junit: {
      outputDir: `${appRoot}/testReports`,
      packageName: process.env.ROLE
    }
`