### PR TITLE
Avoid using objects keys as names

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -30,29 +30,35 @@ class JunitReporter extends events.EventEmitter {
         })
     }
 
+    prepareName (name) {
+        return name.toLowerCase().split(/[^a-z0-9]+/).filter((item) => item && item.length).join('_')
+    }
+
     prepareXml (capabilities) {
         const builder = junit.newBuilder()
-        const packageName = this.options.packageName ? `${capabilities.sanitizedCapabilities} - ${this.options.packageName}`: capabilities.sanitizedCapabilities;
+        const packageName = this.options.packageName ? `${capabilities.sanitizedCapabilities} - ${this.options.packageName}` : capabilities.sanitizedCapabilities
 
         for (let specId of Object.keys(capabilities.specs)) {
             const spec = capabilities.specs[specId]
 
-            for (let suiteName of Object.keys(spec.suites)) {
-                const suite = spec.suites[suiteName]
+            for (let suiteKey of Object.keys(spec.suites)) {
+                const suite = spec.suites[suiteKey]
+                const suiteName = this.prepareName(suite.title)
                 const testSuite = builder.testSuite()
-                    .name(suiteName.toLowerCase().split(/[^a-z0-9]+/).filter((item) => item && item.length).join('_'))
-                    .timestamp(spec.suites[suiteName].start)
-                    .time(spec.suites[suiteName].duration / 1000)
+                    .name(suiteName)
+                    .timestamp(suite.start)
+                    .time(suite.duration / 1000)
                     .property('specId', specId)
-                    .property('suiteName', suiteName)
+                    .property('suiteName', suite.title)
                     .property('capabilities', capabilities.sanitizedCapabilities)
 
-                for (let testName of Object.keys(suite.tests)) {
-                    const test = suite.tests[testName]
+                for (let testKey of Object.keys(suite.tests)) {
+                    const test = suite.tests[testKey]
+                    const testName = this.prepareName(test.title)
                     const testCase = testSuite.testCase()
                         .className(`${packageName}.${suiteName}`)
                         .name(testName)
-                        .time(suite.tests[testName].duration / 1000)
+                        .time(test.duration / 1000)
 
                     if (test.state === 'pending') {
                         testCase.skipped()


### PR DESCRIPTION

A fix for issue https://github.com/webdriverio/wdio-junit-reporter/issues/22

Instead of using the object keys as names, which contains numbers, this change will use the suite.title and test.title as names.