### PR TITLE
Update junit-report-builder to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/webdriverio/wdio-junit-reporter#readme",
   "dependencies": {
-    "junit-report-builder": "^1.1.1",
+    "junit-report-builder": "^1.2.0",
     "babel-runtime": "^5.8.25",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
Hi, I fixed a bug upstream in junit-report-builder while using wdio-junit-reporter.  Thought I'd push this though the ecosystem.  

This new version fixes a crash when emoji characters are present in stdout/stderr.