### PR TITLE
xit jasmine fail fix

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -35,7 +35,9 @@ class JunitReporter extends events.EventEmitter {
     }
 
     prepareName (name) {
-        return name.toLowerCase().split(this.suiteNameRegEx).filter(
+        let normalized = (name) ? name : 'not defined';
+        
+        return normalized.toLowerCase().split(this.suiteNameRegEx).filter(
             (item) => item && item.length
         ).join('_')
     }


### PR DESCRIPTION
using `wdio-jasmine-framework` found this issue, when test in suite is switched off (with `xit` - https://jasmine.github.io/2.0/introduction.html#section-Pending_Specs)

The error itself is:
TypeError: Cannot read property 'toLowerCase' of undefined
    at JunitReporter.prepareName (d:\work\selenium\selenium_ide_tests\webdriverIO\node_modules\wdio-junit-reporter\build\reporter.js:98:24)
    at JunitReporter.prepareXml (d:\work\selenium\selenium_ide_tests\webdriverIO\node_modules\wdio-junit-reporter\build\reporter.js:147:57)

When `xit()` is called, tests name is ignored, and `undefined` returned. 
Code fails, and .xml report will not be created.