### PR TITLE
fix a crash when using cucumber hooks

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -70,24 +70,26 @@ class JunitReporter extends events.EventEmitter {
                     .property('file', spec.files[0].replace(process.cwd(), '.'))
 
                 for (let testKey of Object.keys(suite.tests)) {
-                    const test = suite.tests[testKey]
-                    const testName = this.prepareName(test.title)
-                    const testCase = testSuite.testCase()
-                        .className(`${packageName}.${suiteName}`)
-                        .name(testName)
-                        .time(test.duration / 1000)
+                    if (testKey !== 'undefined') { // fix cucumber hooks crashing reporter
+                        const test = suite.tests[testKey]
+                        const testName = this.prepareName(test.title)
+                        const testCase = testSuite.testCase()
+                            .className(`${packageName}.${suiteName}`)
+                            .name(testName)
+                            .time(test.duration / 1000)
 
-                    if (test.state === 'pending') {
-                        testCase.skipped()
+                        if (test.state === 'pending') {
+                            testCase.skipped()
+                        }
+
+                        if (test.error) {
+                            testCase.error(test.error.message)
+                            testCase.standardError(`\n${test.error.stack}\n`)
+                        }
+
+                        const output = this.getStandardOutput(test)
+                        if (output) testCase.standardOutput(`\n${output}\n`)
                     }
-
-                    if (test.error) {
-                        testCase.error(test.error.message)
-                        testCase.standardError(`\n${test.error.stack}\n`)
-                    }
-
-                    const output = this.getStandardOutput(test)
-                    if (output) testCase.standardOutput(`\n${output}\n`)
                 }
             }
         }

--- a/test/fixtures/cucumberRunner.json
+++ b/test/fixtures/cucumberRunner.json
@@ -1,0 +1,90 @@
+{
+  "runners": {
+    "0-0": {
+      "type": "runner",
+      "start": "2017-07-06T12:58:41.492Z",
+      "_duration": 0,
+      "cid": "0-0",
+      "capabilities": {
+        "platformName": "Android",
+        "deviceName": "Nexus 5"
+      },
+      "sanitizedCapabilities": "nexus5.android",
+      "specs": {
+        "ee317ec04b8745d10159cc033b1a95a0": {
+          "type": "spec",
+          "start": "2017-07-06T12:58:41.492Z",
+          "_duration": 16348,
+          "files": [
+            "/path/to/file3.spec.js"
+          ],
+          "specHash": "ee317ec04b8745d10159cc033b1a95a0",
+          "suites": {
+            "Some foobaz test1": {
+              "type": "suite",
+              "start": "2017-07-06T12:58:50.249Z",
+              "_duration": 5605,
+              "uid": "Some foobaz test1",
+              "title": "Some foobaz test",
+              "tests": {},
+              "hooks": {},
+              "end": "2017-07-06T12:58:55.854Z"
+            },
+            "Some other foobaz test3": {
+              "type": "suite",
+              "start": "2017-07-06T12:58:50.250Z",
+              "_duration": 5602,
+              "uid": "Some other foobaz test3",
+              "title": "Some other foobaz test",
+              "tests": {
+                "I do some foo4": {
+                  "type": "test",
+                  "start": "2017-07-06T12:58:50.252Z",
+                  "_duration": 0,
+                  "uid": "I do some foo4",
+                  "title": "I do some foo",
+                  "state": "pass",
+                  "screenshots": [],
+                  "output": []
+                },
+                "I do some baz5": {
+                  "type": "test",
+                  "start": "2017-07-06T12:58:52.267Z",
+                  "_duration": 0,
+                  "uid": "I do some baz5",
+                  "title": "I do some baz",
+                  "state": "pass",
+                  "screenshots": [],
+                  "output": []
+                },
+                "I get some barbaz6": {
+                  "type": "test",
+                  "start": "2017-07-06T12:58:53.545Z",
+                  "_duration": 0,
+                  "uid": "I get some barbaz6",
+                  "title": "I get some barbaz",
+                  "state": "pass",
+                  "screenshots": [],
+                  "output": []
+                },
+                "undefined": {
+                  "type": "test",
+                  "start": "2017-07-06T12:58:55.851Z",
+                  "_duration": 0,
+                  "uid": "undefined",
+                  "state": "",
+                  "screenshots": [],
+                  "output": []
+                }
+              },
+              "hooks": {},
+              "end": "2017-07-06T12:58:55.852Z"
+            }
+          },
+          "end": "2017-07-06T12:58:57.840Z"
+        }
+      },
+      "sessionID": "e81e204e-0305-4860-badb-eb09ec38ffa0"
+    }
+  }
+}

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -5,6 +5,7 @@ import libxml from 'libxmljs'
 
 import JunitReporter from '../lib/reporter'
 import runnersFixture from './fixtures/runners.json'
+import cucumberRunnerFixture from './fixtures/cucumberRunner.json'
 
 let reporter = null
 const outputDir = path.join(__dirname, 'tmp')
@@ -166,6 +167,28 @@ with new line
 
         it('should have package name in classname', () => {
             xml1Content.should.containEql('classname="phantomjs-____O.o____.some_foobar_test"')
+        })
+    })
+
+    describe('cucumber tests', () => {
+        before(() => {
+            const baseReporterCucumber = {
+                stats: cucumberRunnerFixture,
+                limit: (text) => text,
+                epilogue: () => {}
+            }
+
+            reporter = new JunitReporter(baseReporterCucumber, {}, { outputDir })
+        })
+
+        after(() => {
+            rimraf.sync(outputDir)
+        })
+
+        it('should not crash when fed by cucumber', () => {
+            reporter.onEnd()
+            const files = fs.readdirSync(outputDir)
+            files.should.have.lengthOf(1)
         })
     })
 })


### PR DESCRIPTION
Fixes a crash when using cucumber hooks (https://github.com/webdriverio/wdio-junit-reporter/issues/65)

Cucumber hooks will add an "undefined" test in suite.tests
See following example:
```
suite.tests: { 'I launch app5':
   TestStats {
     type: 'test',
     start: 2017-07-03T14:54:12.771Z,
     _duration: 0,
     uid: 'I launch app5',
     title: 'I launch app',
     state: 'pass',
     screenshots: [],
     output: [] },
  'I click FB login6':
   TestStats {
     type: 'test',
     start: 2017-07-03T14:54:14.780Z,
     _duration: 0,
     uid: 'I click FB login6',
     title: 'I click FB login',
     state: 'pass',
     screenshots: [],
     output: [] },
  undefined:
   TestStats {
     type: 'test',
     start: 2017-07-03T14:54:16.248Z,
     _duration: 0,
     uid: 'undefined',
     title: undefined,
     state: '',
     screenshots: [],
     output: [] } }
```

This PR fixes the crash by verifying that the test is not undefined before doing anything with it.