### PR TITLE
use fullTitle of a suite in reporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -72,7 +72,7 @@ class JunitReporter extends events.EventEmitter {
                 }
 
                 const suite = spec.suites[suiteKey]
-                const title = this.fullTitle(cid, suite.uid)
+                const title = this.title(cid, suite.uid)
                 const suiteName = this.prepareName(title)
                 const testSuite = builder.testSuite()
                     .name(suiteName)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,20 +15,33 @@ class JunitReporter extends events.EventEmitter {
         super()
 
         this.baseReporter = baseReporter
+        this.suitTitles = {}
         this.config = config
         this.options = options
         this.suiteNameRegEx = this.options.suiteNameFormat instanceof RegExp
             ? this.options.suiteNameFormat
             : /[^a-z0-9]+/
 
+        this.on('runner:start', function (runner) {
+            this.suitTitles[runner.cid] = {}
+        })
+
+        this.on('suite:start', function (suite) {
+            this.suitTitles[suite.cid][suite.uid] = suite.fullTitle;
+        })
+
         this.on('end', ::this.onEnd)
+    }
+
+    title (cid, uid) {
+        return this.suitTitles[cid][uid];
     }
 
     onEnd () {
         const { epilogue } = this.baseReporter
         for (let cid of Object.keys(this.baseReporter.stats.runners)) {
             const capabilities = this.baseReporter.stats.runners[cid]
-            const xml = this.prepareXml(capabilities)
+            const xml = this.prepareXml(capabilities, cid)
             this.write(capabilities, cid, xml)
         }
         epilogue.call(this.baseReporter)
@@ -40,7 +53,7 @@ class JunitReporter extends events.EventEmitter {
         ).join('_')
     }
 
-    prepareXml (capabilities) {
+    prepareXml (capabilities, cid) {
         const builder = junit.newBuilder()
         const packageName = this.options.packageName
             ? `${capabilities.sanitizedCapabilities}-${this.options.packageName}`
@@ -59,13 +72,14 @@ class JunitReporter extends events.EventEmitter {
                 }
 
                 const suite = spec.suites[suiteKey]
-                const suiteName = this.prepareName(suite.title)
+                const title = this.fullTitle(cid, suite.uid);
+                const suiteName = this.prepareName(title)
                 const testSuite = builder.testSuite()
                     .name(suiteName)
                     .timestamp(suite.start)
                     .time(suite.duration / 1000)
                     .property('specId', specId)
-                    .property('suiteName', suite.title)
+                    .property('suiteName', title)
                     .property('capabilities', capabilities.sanitizedCapabilities)
                     .property('file', spec.files[0].replace(process.cwd(), '.'))
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,14 +27,14 @@ class JunitReporter extends events.EventEmitter {
         })
 
         this.on('suite:start', function (suite) {
-            this.suitTitles[suite.cid][suite.uid] = suite.fullTitle;
+            this.suitTitles[suite.cid][suite.uid] = suite.fullTitle
         })
 
         this.on('end', ::this.onEnd)
     }
 
     title (cid, uid) {
-        return this.suitTitles[cid][uid];
+        return this.suitTitles[cid][uid]
     }
 
     onEnd () {
@@ -72,7 +72,7 @@ class JunitReporter extends events.EventEmitter {
                 }
 
                 const suite = spec.suites[suiteKey]
-                const title = this.fullTitle(cid, suite.uid);
+                const title = this.fullTitle(cid, suite.uid)
                 const suiteName = this.prepareName(title)
                 const testSuite = builder.testSuite()
                     .name(suiteName)


### PR DESCRIPTION
I have some nested describes in mocha and in junit reporter they look ugly because reporter takes name of inner describe only.
Here's suggested patch to take fullTitle of a suite so in report it will look nicer.
We can make it optional if you want no to break anything.